### PR TITLE
Update Rubocop config

### DIFF
--- a/config/guild.yml
+++ b/config/guild.yml
@@ -12,6 +12,7 @@ AllCops:
     - scripts/**/*
     - Rakefile
     - node_modules/**/*
+    - '*.gemspec'
 
 Metrics/AbcSize:
   Max: 20

--- a/config/guild.yml
+++ b/config/guild.yml
@@ -53,6 +53,9 @@ Style/BlockDelimiters:
 Style/Documentation:
   Enabled: false
 
+Style/GuardClause
+  Enabled: false
+
 Style/Lambda:
   Enabled: false
 

--- a/config/guild.yml
+++ b/config/guild.yml
@@ -19,7 +19,6 @@ Metrics/AbcSize:
 Metrics/BlockLength:
   CountComments: false
   Exclude:
-    - 'Rakefile'
     - '**/*.rake'
     - 'spec/**/*.rb'
 


### PR DESCRIPTION
- Ignore `gemspec` files
- Disable the `Style/GuardClause` cop

The GuardClause cop has been forcing not using `if...else...end` style. We've had a few devs complain so let's turn it off