### PR TITLE
Upgrade dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Change log
+
+## 1.1.2 (2019-07-16)
+
+* upgrades dependencies: 
+  - rubocop / 0.49 -> 0.73
+  - rubocop-rspec / 1.15 -> 1.33.0
+
+  - bundler / 1.15 -> 2.0.2
+  - rake / 10.0 -> 12.3.2
+  - rspec / 3.0 -> 3.8.0

--- a/README.md
+++ b/README.md
@@ -54,5 +54,5 @@ In addition, please follow these guildlines:
 
 Make sure you've been granted publish access to the [rubygem](https://rubygems.org/gems/rubocop-guild)
 
-1. Increment the gem version in `version.rb`
+1. Increment the gem version in rubocop-guild.gemspec
 2. Run `bin/rake release`. This will create a new tag based on the version, push the tag to Github, and then push the gem to Rubygems

--- a/config/guild.yml
+++ b/config/guild.yml
@@ -13,7 +13,6 @@ AllCops:
     - Rakefile
     - node_modules/**/*
     - '*.gemspec'
-  TargetRubyVersion: 2.6.3
 
 Metrics/AbcSize:
   Max: 20

--- a/config/guild.yml
+++ b/config/guild.yml
@@ -13,6 +13,7 @@ AllCops:
     - Rakefile
     - node_modules/**/*
     - '*.gemspec'
+  TargetRubyVersion: 2.6.3
 
 Metrics/AbcSize:
   Max: 20

--- a/rubocop-guild.gemspec
+++ b/rubocop-guild.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "rubocop-guild"
-  spec.version       = "1.0.2"
+  spec.version       = "1.1.2"
   spec.authors       = ["Stafford Brunk"]
   spec.email         = ["stafford@guildeducation.com"]
 
@@ -19,10 +19,10 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "~> 0.49"
-  spec.add_dependency "rubocop-rspec", "~> 1.15"
+  spec.add_dependency "rubocop", "~> 0.73"
+  spec.add_dependency "rubocop-rspec", "~> 1.33.0"
 
-  spec.add_development_dependency "bundler", "~> 1.15"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "bundler", "~> 2.0.2"
+  spec.add_development_dependency "rake", "~> 12.3.2"
+  spec.add_development_dependency "rspec", "~> 3.8.0"
 end


### PR DESCRIPTION
Issues in running guild-rubocop for a new rails/ruby upgrade due to current rubocop version not supporting 2.6.3
> https://codeclimate.com/repos/5a4fa5f7d5e5c20287005835/pull/205


Also @wingrunr21  - I don't have a Guild/rubygem's account